### PR TITLE
Added Action and Mutation property wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,9 @@ struct ContentView: View {
     // access your reactor via the `@EnvironmentObject` property wrapper
     @EnvironmentObject var store: AppReactor
     
-    // you can create a bindind to your state value and action
-    private var name: Binding<String> {
-        store.mutate(binding: \.name) { .nameChanged($0) }
-    }
+    // you can use this property wrapper to bind your value and action
+    @Action(AppReactor.self, keyPath: \.name, action: { .nameChanged($0) })
+    private var name: String
     
     var body: some View {
         VStack {
@@ -175,9 +174,8 @@ In the View everything remains the same except for the binding value:
     @EnvironmentObject var store: AppReactor
 
     // make sure to bind to the `SubReactor` state
-    private var name: Binding<String> {
-        store.mutate(binding: \.subReactor.state.name) { .subReactor(.nameChanged($0)) }
-    }
+    @Action(AppReactor.self, keyPath: \.subReactor.state.name, action: { .subReactor(.nameChanged($0)) })
+    private var name: String
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ struct ContentView: View {
     @EnvironmentObject var store: AppReactor
     
     // you can use this property wrapper to bind your value and action
-    @Action(AppReactor.self, keyPath: \.name, action: { .nameChanged($0) })
+    // it can be used and behaves like the `@State` property wrapper
+    @ActionBinding(AppReactor.self, keyPath: \.name, action: { .nameChanged($0) })
     private var name: String
     
     var body: some View {
@@ -174,7 +175,7 @@ In the View everything remains the same except for the binding value:
     @EnvironmentObject var store: AppReactor
 
     // make sure to bind to the `SubReactor` state
-    @Action(AppReactor.self, keyPath: \.subReactor.state.name, action: { .subReactor(.nameChanged($0)) })
+    @ActionBinding(AppReactor.self, keyPath: \.subReactor.state.name, action: { .subReactor(.nameChanged($0)) })
     private var name: String
 ```
 

--- a/Sources/SwiftUIReactor/Reactor.swift
+++ b/Sources/SwiftUIReactor/Reactor.swift
@@ -68,8 +68,9 @@ public extension Reactor {
 }
 
 /// Property wrapper to get a binding to a state keyPath and a associated Action
+/// Can be used and behaves like the `@State` property wrapper
 @propertyWrapper
-public struct Action<R: Reactor, Value>: DynamicProperty {
+public struct ActionBinding<R: Reactor, Value>: DynamicProperty {
     @EnvironmentObject
     var reactor: R
     
@@ -98,8 +99,9 @@ public struct Action<R: Reactor, Value>: DynamicProperty {
 }
 
 /// Property wrapper to get a binding to a state keyPath and a associated Mutation
+/// Can be used and behaves like the `@State` property wrapper
 @propertyWrapper
-public struct Mutation<R: Reactor, Value>: DynamicProperty {
+public struct MutationBinding<R: Reactor, Value>: DynamicProperty {
     @EnvironmentObject
     var reactor: R
     

--- a/Sources/SwiftUIReactor/Reactor.swift
+++ b/Sources/SwiftUIReactor/Reactor.swift
@@ -110,7 +110,7 @@ public struct Mutation<R: Reactor, Value>: DynamicProperty {
      - Parameters:
          - reactorType: Type of the reactor in the view´s `EnvironmentObject`
          - keyPath: Keypath to the value in the reactor´s state
-         - action: Action to perform in the reactor
+         - mutation: Mutation to perform in the reactor
      */
     public init(_ reactorType: R.Type, keyPath: KeyPath<R.State, Value>, mutation: @escaping (Value) -> R.Mutation) {
         self.keyPath = keyPath

--- a/Sources/SwiftUIReactor/Reactor.swift
+++ b/Sources/SwiftUIReactor/Reactor.swift
@@ -18,7 +18,7 @@ public protocol Reactor: ObservableObject {
     
     /// A State represents the current state of a section in the app.
     associatedtype State
-
+    
     /// ATTENTION: add @Published to this value.
     /// The State represents the current state of a section in the app.
     var state: State { get }
@@ -76,6 +76,12 @@ public struct Action<R: Reactor, Value>: DynamicProperty {
     let keyPath: KeyPath<R.State, Value>
     let action: (Value) -> R.Action
     
+    /**
+     - Parameters:
+         - reactorType: Type of the reactor in the view´s `EnvironmentObject`
+         - keyPath: Keypath to the value in the reactor´s state
+         - action: Action to perform in the reactor
+     */
     public init(_ reactorType: R.Type, keyPath: KeyPath<R.State, Value>, action: @escaping (Value) -> R.Action) {
         self.keyPath = keyPath
         self.action = action
@@ -100,6 +106,12 @@ public struct Mutation<R: Reactor, Value>: DynamicProperty {
     let keyPath: KeyPath<R.State, Value>
     let mutation: (Value) -> R.Mutation
     
+    /**
+     - Parameters:
+         - reactorType: Type of the reactor in the view´s `EnvironmentObject`
+         - keyPath: Keypath to the value in the reactor´s state
+         - action: Action to perform in the reactor
+     */
     public init(_ reactorType: R.Type, keyPath: KeyPath<R.State, Value>, mutation: @escaping (Value) -> R.Mutation) {
         self.keyPath = keyPath
         self.mutation = mutation

--- a/Sources/SwiftUIReactor/Reactor.swift
+++ b/Sources/SwiftUIReactor/Reactor.swift
@@ -66,3 +66,51 @@ public extension Reactor {
         )
     }
 }
+
+/// Property wrapper to get a binding to a state keyPath and a associated Action
+@propertyWrapper
+public struct Action<R: Reactor, Value>: DynamicProperty {
+    @EnvironmentObject
+    var reactor: R
+    
+    let keyPath: KeyPath<R.State, Value>
+    let action: (Value) -> R.Action
+    
+    public init(_ reactorType: R.Type, keyPath: KeyPath<R.State, Value>, action: @escaping (Value) -> R.Action) {
+        self.keyPath = keyPath
+        self.action = action
+    }
+    
+    public var wrappedValue: Value {
+        get { projectedValue.wrappedValue }
+        nonmutating set { projectedValue.wrappedValue = newValue }
+    }
+    
+    public var projectedValue: Binding<Value> {
+        get { reactor.mutate(binding: keyPath, action) }
+    }
+}
+
+/// Property wrapper to get a binding to a state keyPath and a associated Mutation
+@propertyWrapper
+public struct Mutation<R: Reactor, Value>: DynamicProperty {
+    @EnvironmentObject
+    var reactor: R
+    
+    let keyPath: KeyPath<R.State, Value>
+    let mutation: (Value) -> R.Mutation
+    
+    public init(_ reactorType: R.Type, keyPath: KeyPath<R.State, Value>, mutation: @escaping (Value) -> R.Mutation) {
+        self.keyPath = keyPath
+        self.mutation = mutation
+    }
+    
+    public var wrappedValue: Value {
+        get { projectedValue.wrappedValue }
+        nonmutating set { projectedValue.wrappedValue = newValue }
+    }
+    
+    public var projectedValue: Binding<Value> {
+        get { reactor.reduce(binding: keyPath, mutation) }
+    }
+}


### PR DESCRIPTION
Maybe the implementation can be improved. I was just wondering if it was possible to do it.
Feedback welcome.

example usage:
```swift
// AppReactor from the Environment is used
@Action(AppReactor.self, keyPath: \.presentedEntry, action: AppReactor.Action.entrySelected)
private var presentedEntry: PortfolioEntry?

@Mutation(AppReactor.self, keyPath: \.isAddEntryPresented, mutation: AppReactor.Mutation.setIsAddEntryPresented)
private var addEntryPresented: Bool

// usage is consistent with @State
.sheet(isPresented: $addEntryPresented) {
...
}
```