### PR TITLE
Issue #11 - Actions inserted from the transform function do not use up dated state

### DIFF
--- a/Sources/SwiftReactor/Reactor.swift
+++ b/Sources/SwiftReactor/Reactor.swift
@@ -200,9 +200,14 @@ public extension Reactor {
             .eraseToAnyPublisher()
         
         transform(state: state)
-            .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] state in
-                self?.state = state
+                if Thread.current.isMainThread {
+                    self?.state = state
+                } else {
+                    DispatchQueue.main.sync {
+                        self?.state = state
+                    }
+                }
             })
             .store(in: &cancellables)
     }

--- a/Sources/SwiftReactor/Reactor.swift
+++ b/Sources/SwiftReactor/Reactor.swift
@@ -197,7 +197,6 @@ public extension Reactor {
             }
             .filter { $0.forward }
             .map { $0.state }
-            .prepend(initialState)
             .eraseToAnyPublisher()
         
         transform(state: state)

--- a/SwiftReactorExample/SwiftReactorExample/ExampleReactor.swift
+++ b/SwiftReactorExample/SwiftReactorExample/ExampleReactor.swift
@@ -65,6 +65,12 @@ class ExampleReactor: BaseReactor<ExampleReactor.Action, ExampleReactor.Mutation
         
         return newState
     }
+
+    override func transform(action: AnyPublisher<Action, Never>) -> AnyPublisher<Action, Never> {
+        action
+            .prepend(.setSwitchAsync(true))
+            .eraseToAnyPublisher()
+    }
     
     override func transform(mutation: AnyPublisher<Mutation, Never>) -> AnyPublisher<Mutation, Never> {
         mutation


### PR DESCRIPTION
- fixed wrongly used state for transforms
- added tests for the transform functions