### PR TITLE
add ReactorView for reactor lifecycle handling

### DIFF
--- a/Sources/SwiftReactor/EnvironmentReactor.swift
+++ b/Sources/SwiftReactor/EnvironmentReactor.swift
@@ -1,8 +1,8 @@
 //
-//  File.swift
+//  EnvironmentReactor.swift
 //  
 //
-//  Created by Dominik on 08.08.20.
+//  Created by oanhof on 08.08.20.
 //
 
 import SwiftUI

--- a/Sources/SwiftReactor/ReactorView.swift
+++ b/Sources/SwiftReactor/ReactorView.swift
@@ -1,0 +1,41 @@
+//
+//  ReactorView.swift
+//  
+//
+//  Created by oanhof on 23.11.21.
+//
+
+import SwiftUI
+
+/**
+ Used to create a view, where the Reactor lifetime is tied to the views lifecycle.
+ 
+ Example usage:
+ ```
+ .sheet(isPresented: $sheetPresented) {
+     ReactorView(SheetReactor()) {
+         SheetContentView()
+     }
+ }
+ ```
+ */
+@available(watchOS 7.0, *)
+@available(tvOS 14.0, *)
+@available(macOS 11.0, *)
+@available(iOS 14.0, *)
+public struct ReactorView<Content: View, R: Reactor>: View {
+    let content: Content
+    
+    @StateObject
+    private var reactor: R
+    
+    public init(_ reactor: @escaping @autoclosure () -> R, @ViewBuilder content: () -> Content) {
+        _reactor = StateObject(wrappedValue: reactor())
+        self.content = content()
+    }
+    
+    public var body: some View {
+        content
+            .environmentObject(reactor)
+    }
+}

--- a/Sources/SwiftReactorUIKit/BaseReactorView.swift
+++ b/Sources/SwiftReactorUIKit/BaseReactorView.swift
@@ -5,17 +5,17 @@
 //  Created by Julian Pomper on 08.08.20.
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 
 import UIKit
 import Combine
 import SwiftReactor
 
 /// A base class that can be used to simplify
-/// the implementation of the `ReactorView` protocol.
+/// the implementation of the `ReactorUIView` protocol.
 ///
 /// It adds all necessary properties and calls the `bind(reactor:)` method for you, when the `reactor` is being set
-open class BaseReactorView<Reactor: SwiftReactor.Reactor>: UIView, ReactorView {
+open class BaseReactorView<Reactor: SwiftReactor.Reactor>: UIView, ReactorUIView {
     
     public var reactor: Reactor? {
         didSet {
@@ -31,10 +31,10 @@ open class BaseReactorView<Reactor: SwiftReactor.Reactor>: UIView, ReactorView {
 }
 
 /// A base class that can be used to simplify
-/// the implementation of the `ReactorView` protocol.
+/// the implementation of the `ReactorUIView` protocol.
 ///
 /// It adds all necessary properties and calls the `bind(reactor:)` method for you, when the `reactor` is being set
-open class BaseReactorViewController<Reactor: SwiftReactor.Reactor>: UIViewController, ReactorView {
+open class BaseReactorViewController<Reactor: SwiftReactor.Reactor>: UIViewController, ReactorUIView {
     public var reactor: Reactor? {
         didSet {
             guard let reactor = reactor else { return }

--- a/Sources/SwiftReactorUIKit/ReactorUIView.swift
+++ b/Sources/SwiftReactorUIKit/ReactorUIView.swift
@@ -1,5 +1,5 @@
 //
-//  ReactorView.swift
+//  ReactorUIView.swift
 //  
 //
 //  Created by Julian Pomper on 08.08.20.
@@ -16,7 +16,7 @@ import SwiftReactor
 ///
 /// - Important: call the `setAndBind(reactor:)` method to set the reactor and call the `bind(reactor:)` method
 ///
-public protocol ReactorView: class {
+public protocol ReactorUIView: AnyObject {
     associatedtype Reactor = SwiftReactor.Reactor
     /**
         use `setAndBind` to set the reactor and call the `bind(reactor:)` method
@@ -53,7 +53,7 @@ public protocol ReactorView: class {
     func setAndBind(reactor: Reactor)
 }
 
-public extension ReactorView {
+public extension ReactorUIView {
     func setAndBind(reactor: Reactor) {
         self.reactor = reactor
         bind(reactor: reactor)

--- a/SwiftReactorExample/SwiftReactorExample/ContentView.swift
+++ b/SwiftReactorExample/SwiftReactorExample/ContentView.swift
@@ -22,6 +22,9 @@ struct ContentView: View {
     @ActionBinding(\ExampleReactor.self, keyPath: \.backgroundColor, action: ExampleReactor.Action.colorChangePressed)
     private var backgroundColor: Color
     
+    @State
+    private var sheetPresented = false
+    
     var body: some View {
         VStack(spacing: 8) {
             TextField("Text", text: $text)
@@ -39,9 +42,28 @@ struct ContentView: View {
             }, label: {
                 Text("Random Color")
             })
+            
+            if #available(iOS 14.0, *) {
+                NavigationLink("Navigate") {
+                    ReactorView(ExampleReactor()) {
+                        ContentView()
+                    }
+                }
+                
+                Button("Present") {
+                    sheetPresented = true
+                }
+            }
         }
         .padding()
         .background(backgroundColor)
+        .sheet(isPresented: $sheetPresented) {
+            if #available(iOS 14.0, *) {
+                ReactorView(ExampleReactor()) {
+                    ContentView()
+                }
+            }
+        }
     }
 }
 

--- a/SwiftReactorExample/SwiftReactorExample/SceneDelegate.swift
+++ b/SwiftReactorExample/SwiftReactorExample/SceneDelegate.swift
@@ -22,11 +22,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Create the SwiftUI view that provides the window contents.
         let contentView = ContentView()
             .environmentObject(ExampleReactor())
+        
+        let navigationView = NavigationView {
+            contentView
+        }
 
         // Use a UIHostingController as window root view controller.
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
-            window.rootViewController = UIHostingController(rootView: contentView)
+            window.rootViewController = UIHostingController(rootView: navigationView)
             self.window = window
             window.makeKeyAndVisible()
         }

--- a/Tests/SwiftReactorUIKitTests/SwiftReactorUIKitTests.swift
+++ b/Tests/SwiftReactorUIKitTests/SwiftReactorUIKitTests.swift
@@ -5,7 +5,7 @@
 //  Created by Julian Pomper on 08.08.20.
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 
 import UIKit
 import Combine
@@ -76,7 +76,7 @@ final class BaseCountingViewController: BaseReactorViewController<CountingReacto
     }
 }
 
-final class CountingViewController: UIViewController, ReactorView {
+final class CountingViewController: UIViewController, ReactorUIView {
     typealias Reactor = CountingReactor
     
     var reactor: Reactor?


### PR DESCRIPTION
Adds a new `ReactorView` view that ties the reactor lifetime to the view lifecycle using `@StateObject`.